### PR TITLE
Fix incorrect #define in header guard.

### DIFF
--- a/Include/Library/MiscProtocolLib.h
+++ b/Include/Library/MiscProtocolLib.h
@@ -15,7 +15,7 @@
 **/
 
 #ifndef MISC_PROTOCOL_LIB_H_
-#define EFI_PROTOCOL_LIB_H_
+#define MISC_PROTOCOL_LIB_H_
 
 // SafeInstallProtocolInterface
 EFI_STATUS


### PR DESCRIPTION
Header guard in Include/Library/MiscProtocolLib.h incorrectly `#defines EFI_PROTOCOL_LIB_H_`, which is undefined and does not match `MISC_PROTOCOL_LIB_H_`, the expected definition.
